### PR TITLE
Consider binder for easy user evaluation without setting up local environment.

### DIFF
--- a/1d_slice_selective_optimal_control.ipynb
+++ b/1d_slice_selective_optimal_control.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib notebook\n",
+    "%matplotlib inline\n",
     "import numpy as np\n",
     "\n",
     "import pulpy as pp\n",

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-This badge launches the complete folder in jupyter-notbook:
+This badge launches the complete folder in jupyter-notbook (*** change ***):
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/curtcorum/pulpy-tutorials/ccjoss)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/curtcorum/pulpy-tutorials/ccjoss/?urlpath=lab)
 
 This is a collection of jupyter notebooks demonstration the functionality of the PulPy python package for MR RF pulse and gradient waveform design.
 
 Binder links for each notebook with description:
 
+Adibatic pulse design. Examples of bir4, blah blah: (*** change ***)
 
-
-
+Next notebook description: <link>

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ This is a collection of jupyter notebooks demonstration the functionality of the
 
 Binder links for each notebook with description:
 
-Adibatic pulse design. Examples of bir4, blah blah: https://mybinder.org/v2/gh/curtcorum/pulpy-tutorials/ccjoss/?urlpath=lab/tree/adiabatic_pulse_design.ipynb (*** change ***)
+Adibatic pulse design. Examples of bir4, blah blah
 
-Next notebook description: <link>
+https://mybinder.org/v2/gh/curtcorum/pulpy-tutorials/ccjoss/?urlpath=lab/tree/adiabatic_pulse_design.ipynb (*** change ***)
+
+Next notebook description
+
+<link>

--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@ This is a collection of jupyter notebooks demonstration the functionality of the
 
 Binder links for each notebook with description:
 
-Adibatic pulse design. Examples of bir4, blah blah: (*** change ***)
+Adibatic pulse design. Examples of bir4, blah blah: https://mybinder.org/v2/gh/curtcorum/pulpy-tutorials/ccjoss/?urlpath=lab/tree/adiabatic_pulse_design.ipynb (*** change ***)
 
 Next notebook description: <link>

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-This is a collection of jupyter notebooks demonstration the functionality of the PulPy python package for MR RF pulse and gradient waveform design. 
+This badge launches the complete folder in jupyter-notbook:
+
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/curtcorum/pulpy-tutorials/ccjoss)
+
+This is a collection of jupyter notebooks demonstration the functionality of the PulPy python package for MR RF pulse and gradient waveform design.
+
+Binder links for each notebook with description:
+
+
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+numba
+numpy
+PyWavelets
+scipy
+tqdm
+sigpy
+pulpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ scipy
 tqdm
 sigpy
 pulpy
+matplotlib


### PR DESCRIPTION
https://github.com/openjournals/joss-reviews/issues/6586

Here is a suggestion for hosting the tutorials at binder.

See the `README.md` at: https://github.com/curtcorum/pulpy-tutorials/tree/ccjoss

There is now a bare-bones requirements.txt as suggested in #1 but it is not tested beyond the `adiabatic_pulse_design.ipynb` notebook.

The badge and links needs to be updated to point to the main repository, not the fork.

Placing a brief description in `README.md` as suggested in #2 and linking to binder for each example would make it much easier for potential users to evaluate. References to or from the paper could be linked or noted here, or inside the notebooks.

In the notebooks `%matplotlib notebook` needs to be changed to `%matplotlib inline` or else other dependencies figured out.

The links are pointing to jupyterlab instances, not the default jupyter notebook, but whichever is used should be debugged.

See: https://github.com/binder-examples/jupyterlab



